### PR TITLE
Lower engine requirements to node 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "BSD-3-Clause",
   "main": "lib/tiny-lru.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=6"
   },
   "engineStrict": true,
   "scripts": {


### PR DESCRIPTION
Package.json is too aggressive with engine requirements, module works just fine with node@6. Also you're running tests on travis under node@6, so it's definitely supported.

https://github.com/avoidwork/tiny-lru/blob/master/.travis.yml#L6