### PR TITLE
Modernization Niceties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1840,6 +1840,12 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+      "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==",
+      "dev": true
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -5508,9 +5514,9 @@
       "dev": true
     },
     "react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.10.0.tgz",
+      "integrity": "sha512-WRki2sBb7MTpYp7FtDEmSeGKX2vamYyq3rc9o7fKUG+/DHVyJu69NnvJsiSwwhh2Tt8XN40MQHkDBEXwyfxncQ==",
       "dev": true
     },
     "read-pkg": {
@@ -7060,14 +7066,15 @@
       "dev": true
     },
     "tslib-cli": {
-      "version": "5.0.17",
-      "resolved": "https://registry.npmjs.org/tslib-cli/-/tslib-cli-5.0.17.tgz",
-      "integrity": "sha512-tGv064TZWUHX3xQjZOb/TrsAU3r1cKjeR+o6Fta048PgQk24Wb8qHZoMGRMqMPBOvNLQcYujW4X8fEUjYUEwuw==",
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/tslib-cli/-/tslib-cli-5.0.18.tgz",
+      "integrity": "sha512-9gYtN0M5vxLddWDHUj9hIriXhnAC81uY4BXHXCnYdxtB54fFOdmgDBalOl/QxoAHkkHv+ZqntjLtvvNS7XKSaQ==",
       "dev": true,
       "requires": {
         "builtin-modules": "^3.1.0",
         "chalk": "^2.4.2",
         "coveralls": "^3.0.6",
+        "deepmerge": "^4.0.0",
         "del": "^5.1.0",
         "is-ci": "^2.0.0",
         "jest": "^24.9.0",
@@ -7081,13 +7088,13 @@
         "rollup-plugin-executable": "^1.5.0",
         "rollup-plugin-filesize": "^6.2.0",
         "rollup-plugin-json": "^4.0.0",
-        "rollup-plugin-livereload": "^1.0.1",
+        "rollup-plugin-livereload": "^1.0.3",
         "rollup-plugin-node-globals": "^1.4.0",
         "rollup-plugin-node-resolve": "^5.2.0",
         "rollup-plugin-replace": "^2.2.0",
         "rollup-plugin-serve": "^1.0.1",
         "rollup-plugin-terser": "^5.1.2",
-        "rollup-plugin-typescript2": "^0.24.2",
+        "rollup-plugin-typescript2": "^0.24.3",
         "ts-jest": "^24.1.0",
         "tslib": "^1.10.0",
         "tslint": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "tslib-cli": "^5.0.17",
+    "tslib-cli": "^5.0.18",
     "nodeunit": "^0.11.3",
     "precise": "^1.1.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-	"exclude": ["node_modules", "dist"],
+	"exclude": ["node_modules", "lib"],
 	"compilerOptions": {
 		"lib": ["dom", "esnext"],
 		"module": "esnext",
 		"moduleResolution": "node",
-		"outDir": "dist",
+		"outDir": "lib",
 		"strict": false,
 		"target": "esnext",
 		"allowJs": true,


### PR DESCRIPTION
This fixes few issues I noticed after PR #27.

- upgrade `tslib-cli` to fix below warning generated during builds:
![image](https://user-images.githubusercontent.com/802242/65807089-bc501700-e141-11e9-88f0-5d6f0b0123d4.png)
- fix an oversite in `tsconfig.json` related to `outDir` - it being `lib`, not `dist`

This update can be bundled in next time we cut a new release. 

If you prefer releasing it now, a `patch` release would suffice.