### PR TITLE
Include missing props in the TypeScript definition

### DIFF
--- a/tiny-lru.d.ts
+++ b/tiny-lru.d.ts
@@ -2,6 +2,12 @@ declare module "tiny-lru" {
   class Lru<T = any> {
     constructor(max?: number, ttl?: number);
 
+    public max: number;
+    public ttl: number;
+    public size: boolean;
+    public first: T | null;
+    public last: T | null;
+
     public has(key: string): boolean;
     public get(key: string): T | undefined;
     public set(key: string, value: T, bypass?: boolean): this;

--- a/tiny-lru.d.ts
+++ b/tiny-lru.d.ts
@@ -4,7 +4,7 @@ declare module "tiny-lru" {
 
     public max: number;
     public ttl: number;
-    public size: boolean;
+    public size: number;
     public first: T | null;
     public last: T | null;
 


### PR DESCRIPTION
Currently when I use `tiny-lru` in a TypeScript project I get a type error when I read `cache.size`, as it's not defined in the definition file.

I'm updating the definition file to include all the properties which are mentioned in the readme.