### PR TITLE
fix: Manual typings with generics

### DIFF
--- a/lru.d.ts
+++ b/lru.d.ts
@@ -1,18 +1,18 @@
 export function lru<T = any>(max?: number, ttl?: number): LRU<T>;
 export interface LRU<T> {
-    first: T;
-    items: Record<string, T>;
-    last: T;
+    first: T | null;
+    last: T | null;
     max: number;
     size: number;
     ttl: number;
+
     has(key: any): boolean;
-    clear(): LRU<T>;
-    delete(key: any): LRU<T>;
-    evict(bypass?: boolean): LRU<T>;
-    get(key: any): T;
+    clear(): this;
+    delete(key: any): this;
+    evict(bypass?: boolean): this;
+    get(key: any): T | undefined;
     keys(): string[];
-    set(key: any, value: T, bypass?: boolean): LRU<T>;
+    set(key: any, value: T, bypass?: boolean): this;
 }
 export { };
 

--- a/lru.d.ts
+++ b/lru.d.ts
@@ -1,18 +1,18 @@
-export function lru(max?: number, ttl?: number): LRU;
-declare class LRU {
-    constructor(max?: number, ttl?: number);
-    first: any;
-    items: any;
-    last: any;
+export function lru<T = any>(max?: number, ttl?: number): LRU<T>;
+export interface LRU<T> {
+    first: T;
+    items: Record<string, T>;
+    last: T;
     max: number;
     size: number;
     ttl: number;
     has(key: any): boolean;
-    clear(): LRU;
-    delete(key: any): LRU;
-    evict(bypass?: boolean): LRU;
-    get(key: any): any;
+    clear(): LRU<T>;
+    delete(key: any): LRU<T>;
+    evict(bypass?: boolean): LRU<T>;
+    get(key: any): T;
     keys(): string[];
-    set(key: any, value: any, bypass?: boolean): LRU;
+    set(key: any, value: T, bypass?: boolean): LRU<T>;
 }
-export {};
+export { };
+


### PR DESCRIPTION
With 9.x release we lost some accuracy in types.

compared to 8.x series https://github.com/avoidwork/tiny-lru/blob/8.0.2/tiny-lru.d.ts