### PR TITLE
Make .get always return a value, even if it is expired

### DIFF
--- a/src/lru.js
+++ b/src/lru.js
@@ -73,10 +73,11 @@ class LRU {
 		if (this.has(key)) {
 			const item = this.items[key];
 
+			result = item.value;
+
 			if (this.ttl > 0 && item.expiry <= new Date().getTime()) {
 				this.delete(key);
 			} else {
-				result = item.value;
 				this.set(key, result, true);
 			}
 		}


### PR DESCRIPTION
This could be an issue instead of a pull request, you can consider this a discussion starter if you want.

I ran into an issue recently when doing this:

```js
if (cache.has(key)) {
	const value = cache.get(key)
	// assume that value is a legit value
}
```

I ran into issues because `cache.has` will return true if the item is in the map, but then the call to `cache.get` would delete the item if it was expired and return undefined, and I would get runtime errors because I assumed that `cache.has` meant that I could safely call `cache.get` in the same tick.