### PR TITLE
Implement getExpirationTime operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Gets cached item and moves it to the front
 const item = cache.get("myKey");
 ```
 
-## getExpirationTime
+## expiresAt
 ### Method
 
 Gets expiration time for cached item
@@ -95,7 +95,7 @@ Gets expiration time for cached item
 **Example**
 
 ```javascript
-const item = cache.getExpirationTime("myKey");
+const item = cache.expiresAt("myKey");
 ```
 
 ## keys

--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ Gets cached item and moves it to the front
 const item = cache.get("myKey");
 ```
 
+## getExpirationTime
+### Method
+
+Gets expiration time for cached item
+
+	param  {String} key Item key
+	return {Mixed}      Undefined or number (epoch time)
+
+**Example**
+
+```javascript
+const item = cache.getExpirationTime("myKey");
+```
+
 ## keys
 ### Method
 

--- a/src/lru.js
+++ b/src/lru.js
@@ -84,6 +84,16 @@ class LRU {
 		return result;
 	}
 
+	getExpirationTime (key) {
+		let result;
+
+		if (this.#has(key)) {
+			result = this.items[key].expiry;
+		}
+
+		return result;
+	}
+
 	keys () {
 		return Object.keys(this.items);
 	}

--- a/src/lru.js
+++ b/src/lru.js
@@ -84,7 +84,7 @@ class LRU {
 		return result;
 	}
 
-	getExpirationTime (key) {
+	expiresAt (key) {
 		let result;
 
 		if (this.#has(key)) {

--- a/test/lru.js
+++ b/test/lru.js
@@ -101,14 +101,10 @@ describe("Testing functionality", function () {
 		assert.equal(this.cache.size, 0, "Should be 'null'");
 	});
 
-	it("It should return expiration time", function () {
-		const ttl = 99999;
-		this.cache = lru(1, ttl);
-		const now = new Date();
-		this.cache.set("key", "value");
-		const expirationTime = this.cache.getExpirationTime("key");
-		const remainingTime = expirationTime - now.getTime();
-		// keep 100 msec margin of error just in case
-		assert.equal(99999 - remainingTime < 100, true, "Should be within a margin of error");
+	it("It should expose expiration time", function () {
+		this.cache = lru(1, 6e4);
+		this.cache.set(this.items[0], false);
+		assert.equal(typeof this.cache.expiresAt(this.items[0]), "number", "Should be a number");
+		assert.equal(this.cache.expiresAt("invalid"), undefined, "Should be undefined");
 	});
 });

--- a/test/lru.js
+++ b/test/lru.js
@@ -100,4 +100,15 @@ describe("Testing functionality", function () {
 		assert.equal(this.cache.last, null, "Should be 'null'");
 		assert.equal(this.cache.size, 0, "Should be 'null'");
 	});
+
+	it("It should return expiration time", function () {
+		const ttl = 99999;
+		this.cache = lru(1, ttl);
+		const now = new Date();
+		this.cache.set("key", "value");
+		const expirationTime = this.cache.getExpirationTime("key");
+		const remainingTime = expirationTime - now.getTime();
+		// keep 100 msec margin of error just in case
+		assert.equal(99999 - remainingTime < 100, true, "Should be within a margin of error");
+	});
 });


### PR DESCRIPTION
This PR implement support for retrieving expiration time for a given entry.

Use-case that we have for this: we want to do proactive background cache refresh after half of the TTL has passed, but currently it's not possible to retrieve this information for a specific cache entry.