### PR TITLE
Use faster way for getting unix time

### DIFF
--- a/src/lru.js
+++ b/src/lru.js
@@ -74,7 +74,7 @@ class LRU {
 		if (this.#has(key)) {
 			const item = this.items[key];
 
-			if (this.ttl > 0 && item.expiry <= new Date().getTime()) {
+			if (this.ttl > 0 && item.expiry <= Date.now()) {
 				this.delete(key);
 			} else {
 				result = item.value;
@@ -107,7 +107,7 @@ class LRU {
 			item.value = value;
 
 			if (resetTtl) {
-				item.expiry = this.ttl > 0 ? new Date().getTime() + this.ttl : this.ttl;
+				item.expiry = this.ttl > 0 ? Date.now() + this.ttl : this.ttl;
 			}
 
 			if (this.last !== item) {
@@ -137,7 +137,7 @@ class LRU {
 			}
 
 			item = this.items[key] = {
-				expiry: this.ttl > 0 ? new Date().getTime() + this.ttl : this.ttl,
+				expiry: this.ttl > 0 ? Date.now() + this.ttl : this.ttl,
 				key: key,
 				prev: this.last,
 				next: null,


### PR DESCRIPTION
See https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/v18/RESULTS-v18_14_0.md#getting-unix-time

`Date.now()` is 2.5 times faster.