### PR TITLE
Add new method bumpLru in order to get rid of redundant operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,19 +137,6 @@ const cache = lru();
 cache.last; // null - it's a new cache!
 ```
 
-## resetTtl
-### Property
-
-Resets `item.expiry` with each `set()` if `true` (false)
-
-**Example**
-
-```javascript
-const cache = lru();
-
-cache.resetTtl; // false
-```
-
 ## set
 ### Method
 

--- a/src/lru.js
+++ b/src/lru.js
@@ -30,6 +30,10 @@ class LRU {
 				next.prev = prev;
 			}
 		}
+
+		this.last = item;
+
+		return this;
 	}
 
 	clear () {

--- a/src/lru.js
+++ b/src/lru.js
@@ -95,20 +95,19 @@ class LRU {
 	}
 
 	get (key) {
-		let result;
-
 		if (this.items.has(key)) {
 			const item = this.items.get(key);
 
 			if (this.ttl > 0 && item.expiry <= Date.now()) {
 				this.delete(key);
 			} else {
-				result = item.value;
 				this.bumpLru(item);
+
+				return item.value;
 			}
 		}
 
-		return result;
+		return undefined;
 	}
 
 	keys () {


### PR DESCRIPTION
There is some code duplication, in order to avoid paying a method call cost. If you are OK with sacrificing a bit of perf, `set` could also invoke `bumpLru` under-the-hood.

This also removes `resetTtl` parameter, as it is no longer necessary - and I also finally realized why changing default behaviour wasn't a great idea and could prevent entry from ever expiring - I didn't understand at first that every `get` operation also calls `set` under the hood. Now that this is no longer the case, explicit `set` operations can bump the TTL always.

Benchmark before:
Run 1 Set (Low Keys): 0.6499 ms
Run 2 Evict (High Keys): 0.9111 ms
Run 3 Evict (Low Keys): 1.2778 ms
Run 4 Evict (High Keys): 0.1708 ms
Run 5 Get (High Keys): 0.6711 ms

Benchmark after:

Run 1 Set (Low Keys): 0.5414 ms
Run 2 Evict (High Keys): 0.9048 ms
Run 3 Evict (Low Keys): 1.1438 ms
Run 4 Evict (High Keys): 0.3994 ms
Run 5 Get (High Keys): 0.5202 ms

No idea why eviction high keys is slower, it wasn't affected at all. Set and get operations are consistently faster, though.